### PR TITLE
Cannot use 'in' operator to search for 'current' in undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,5 +25,5 @@ export function createRefDepsHook(useEffectLike: UseEffectLike) {
 }
 
 function isRefObj(ref: any): ref is RefObject<any> {
-    return (ref !== null || ref !== undefined) && 'current' in ref
+    return ref !== null && ref !== undefined && 'current' in ref
 }


### PR DESCRIPTION
Hi!
Nice hook.
I found an issue. If you pass an undefined to deps array it throws following error:
<img width="1440" alt="Screenshot 2023-04-06 at 8 42 34 AM" src="https://user-images.githubusercontent.com/75017126/230275280-07386120-d52a-4c13-b7ea-729109a03fde.png">
Coming with a quick fix!